### PR TITLE
docs: correct typos in guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ typings/
 
 #Dev
 docs/test.html
+
+#IDEs
+.idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,8 +197,8 @@ BREAKING CHANGE:
 change login route to /users/login
 ```
 
-[coc]: /CODE_OF_CONDUCT.md
-[github]: https://github.com/sfeir-open-source/sfeir-school-template
-[github-issue]: https://github.com/sfeir-open-source/sfeir-school-template/issues/new
-[issue-tracker]: https://github.com/sfeir-open-source/sfeir-school-template/issues
-[github-pulls]: https://github.com/sfeir-open-source/sfeir-school-template/pulls
+[coc]: https://github.com/sfeir-open-source/.github/blob/main/CODE_OF_CONDUCT.md
+[github]: https://github.com/sfeir-open-source/sfeir-school-rxjs
+[github-issue]: https://github.com/sfeir-open-source/sfeir-school-rxjs/issues/new
+[issue-tracker]: https://github.com/sfeir-open-source/sfeir-school-rxjs/issues
+[github-pulls]: https://github.com/sfeir-open-source/sfeir-school-rxjs/pulls

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can view the slides [here](https://sfeir-open-source.github.io/sfeir-school-
 
 ## Develop
 
-To run docs locally, go in directory `docs` and run `npx serve` of if you don't have node, you can use docker `docker-compose up`, and open slides on http://localhost:5000/.
+To run docs locally, go in directory `docs` and run `npx serve` of if you don't have node, you can use docker `docker-compose up`, and open slides on http://localhost:3000/.
 
 ## Workshop
 
@@ -23,7 +23,7 @@ Workshops are in directory `steps` :
   * one with source file to complete
   * a second directory suffixed with `-solution` which contains source file with solutions.
 
-> Note: You may open steps folder with your editor (expecially VSCode)
+> Note: You may open steps folder with your editor (especially VSCode)
 
 ### Start a lab
 
@@ -53,4 +53,4 @@ Want to file a bug, contribute some code, or improve documentation? Excellent! R
 Help us keep Angular open and inclusive. Please read and follow our [Code of Conduct][codeofconduct].
 
 [contributing]: CONTRIBUTING.md
-[codeofconduct]: https://github.com/sfeir-open-source/code-of-conduct/blob/master/CODE_OF_CONDUCT.md
+[codeofconduct]: https://github.com/sfeir-open-source/.github/blob/main/CODE_OF_CONDUCT.md


### PR DESCRIPTION
Quelques erreurs étaient présentes dans le readme et le guide de contribution.

Notamment
- l'url local des slides est sur le port 3000 et non 5000
- plusieurs urls pointaient vers sfeir-school-template plutôt que le repo RxJs