### PR TITLE
fix: lab 06 execution

### DIFF
--- a/steps/06-tests-solution/apple.service.spec.ts
+++ b/steps/06-tests-solution/apple.service.spec.ts
@@ -1,4 +1,4 @@
-import { map, take } from 'rxjs';
+import { map } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { AppleService } from '../common';
 

--- a/steps/06-tests-solution/baking.service.spec.ts
+++ b/steps/06-tests-solution/baking.service.spec.ts
@@ -1,6 +1,6 @@
-import { map, take } from 'rxjs';
+import { map } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { BakingService } from '../common';
+import { BakingService } from '../common/baking.service-solution';
 import { Apple, AppleSlice, Compote, PiePlate } from '../common/models';
 
 jest.setTimeout(10_000);

--- a/steps/package.json
+++ b/steps/package.json
@@ -14,7 +14,7 @@
     "start:04:solution": "ts-node ./04-foncer-la-tarte-solution/index.ts",
     "start:05": "ts-node ./05-cuire-la-tarte/index.ts",
     "start:05:solution": "ts-node ./05-cuire-la-tarte-solution/index.ts",
-    "start:06": "jest ./06-tests",
+    "start:06": "jest ./06-tests/",
     "start:06:solution": "jest ./06-tests-solution",
     "start:99:solution": "ts-node ./99-bonus-simple-mapping/index.ts",
     "start:100:solution": "ts-node ./100-bonus-chevre-chaud/index.ts",


### PR DESCRIPTION
### Problèmes rencontrés
- Le script `start:06` lance les tests des fichiers présents dans les dossiers `06-tests` ET `06-tests-solution`. Seul le premier dossier devrait être concerné
- L'import de `BakingService` dans `baking.service.spec.ts` est imprécis. Il pointe vers un dossier qui propose 2 implémentations de `BakingService`. Pour que les tests puissent réussir quelque soit l'état des exercices précédents, il faut pointer vers la correction de `BakingService` .