### PR TITLE
feat: improve time progression testing explanations

### DIFF
--- a/docs/markdown/06-tests/03-tester-le-temps.md
+++ b/docs/markdown/06-tests/03-tester-le-temps.md
@@ -45,6 +45,7 @@ it('should emit an apple every second', () => {
 
 Notes:
 Décrire le TestScheduler
+Insister sur son utilisation pour avoir des tests "instantanés"
 
 ##==##
 
@@ -63,12 +64,32 @@ Décrire le TestScheduler
 
 ##==##
 
+# Point d'attention: progression du temps
+
+<blockquote>
+<cite>
+NOTE: You may have to subtract 1 millisecond from the time you want to progress because the alphanumeric marbles (representing an actual emitted value) advance time 1 virtual frame themselves already, after they emit. This can be counter-intuitive and frustrating, but for now it is indeed correct.
+</cite>
+</blockquote>
+<blockquote>
+<cite>
+"()" sync groupings: The position of the initial ( determines the time at which its values are emitted. While it can be counter-intuitive at first, after all the values have synchronously emitted time will progress a number of frames equal to the number of ASCII characters in the group, including the parentheses. e.g. '(abc)' will emit the values of a, b, and c synchronously in the same frame and then advance virtual time by 5 frames, '(abc)'.length === 5.
+</cite>
+</blockquote>
+
+[Lien vers la documentation](https://rxjs.dev/guide/testing/marble-testing#time-progression-syntax)
+
+##==##
+
 # Point marble
 
-> --1--2---#
+> --a--b--#
+> --(abc)-|
 
 Notes:
-Expliquer ce marble
+Expliquer ces marbles
+On frame 2 emit a, on frame 5 emit b, and on frame 8, error.
+On frame 2 emit a, b, and c, then on frame 8, complete.
 
 ##==##
 
@@ -78,24 +99,38 @@ Expliquer ce marble
 
 Notes:
 Interroger les participants
+On frame 2 emit a, on frame 5 emit b, and on frame 8, complete.
 
 ##==##
 
 # Point marble
 
-> --^------!
+> --^--!-
 
 Notes:
 Interroger les participants
+on frame 2 a subscription happened, and on frame 5 was unsubscribed
+Equivalent to NEVER, or an observable that never emits or errors or completes
 
 ##==##
 
 # Point marble
 
-> --1--2--(3|)
+> --(a|)
 
 Notes:
 Interroger les participants
+on frame 2 emit a and complete
+
+##==##
+
+# Point marble
+
+> (a)-|
+
+Notes:
+Interroger les participants
+on frame 0 emit a and on frame 4, complete
 
 ##==##
 
@@ -105,6 +140,7 @@ Interroger les participants
 
 Notes:
 Interroger les participants
+on frame 0 emit 1, on frame 4001 emit 3 and complete
 
 ##==##
 
@@ -114,6 +150,7 @@ Interroger les participants
 
 Notes:
 Interroger les participants
+on frame 2 emit 1, on frame 4007 emit 3 and complete
 
 ##==##
 
@@ -163,8 +200,8 @@ it('should emit an apple every second', () => {
 
 ### ❌ `HeartbeatService.getBeat()` est infini
 ### ❌ expected n'est pas exhaustif (comme actual$ est infini)
-### ❌ il passe 1s entre chaque heartbeat mais là on attend 1s entre chaque
 ### ❌ on ne défini pas "h"
+### ❌ souvez-vous: un "alphanumeric marbles" = 1ms
 
 ##==##
 
@@ -180,7 +217,7 @@ it('should emit an apple every second', () => {
     testScheduler.run(({ expectObservable }) => {
         const actual$ = HeartbeatService.getBeat();
         const actualSubscription = '^ 3500ms !';
-        const expected = '1s h 1s h 1s h';
+        const expected = '1s h 999ms h 999ms h';
         expectObservable(actual$, actualSubscription)
             .toBe(expected, { h: { "type": "heartbeat", "status": "OK" } });
     });
@@ -201,7 +238,7 @@ it('should emit an apple every second', () => {
     testScheduler.run(({ expectObservable }) => {
         const actual$ = HeartbeatService.getBeat().pipe(map(() => 'h'));
         const actualSubscription = '^ 3500ms !';
-        const expected = '1s h 1s h 1s h';
+        const expected = '1s h 999ms h 999ms h';
         expectObservable(actual$, actualSubscription).toBe(expected);
     });
 });

--- a/docs/markdown/06-tests/03-tester-le-temps.md
+++ b/docs/markdown/06-tests/03-tester-le-temps.md
@@ -64,16 +64,31 @@ Insister sur son utilisation pour avoir des tests "instantanés"
 
 ##==##
 
-# Point d'attention: progression du temps
+# Point d'attention : progression du temps
 
 <blockquote>
 <cite>
 NOTE: You may have to subtract 1 millisecond from the time you want to progress because the alphanumeric marbles (representing an actual emitted value) advance time 1 virtual frame themselves already, after they emit. This can be counter-intuitive and frustrating, but for now it is indeed correct.
 </cite>
 </blockquote>
+
+##==##
+
+# Point marble
+
+> --a--b--#
+
+Notes:
+Expliquer ces marbles
+On frame 2 emit a, on frame 5 emit b, and on frame 8, error.
+
+##==##
+
+# Point d'attention : progression du temps - subtilité
+
 <blockquote>
 <cite>
-"()" sync groupings: The position of the initial ( determines the time at which its values are emitted. While it can be counter-intuitive at first, after all the values have synchronously emitted time will progress a number of frames equal to the number of ASCII characters in the group, including the parentheses. e.g. '(abc)' will emit the values of a, b, and c synchronously in the same frame and then advance virtual time by 5 frames, '(abc)'.length === 5.
+"()" sync groupings: The position of the initial "(" determines the time at which its values are emitted. While it can be counter-intuitive at first, after all the values have synchronously emitted time will progress a number of frames equal to the number of ASCII characters in the group, including the parentheses. e.g. '(abc)' will emit the values of a, b, and c synchronously in the same frame and then advance virtual time by 5 frames, '(abc)'.length === 5.
 </cite>
 </blockquote>
 
@@ -83,12 +98,10 @@ NOTE: You may have to subtract 1 millisecond from the time you want to progress 
 
 # Point marble
 
-> --a--b--#
 > --(abc)-|
 
 Notes:
 Expliquer ces marbles
-On frame 2 emit a, on frame 5 emit b, and on frame 8, error.
 On frame 2 emit a, b, and c, then on frame 8, complete.
 
 ##==##

--- a/steps/06-tests-solution/apple.service.spec.ts
+++ b/steps/06-tests-solution/apple.service.spec.ts
@@ -3,26 +3,32 @@ import { TestScheduler } from 'rxjs/testing';
 import { AppleService } from '../common';
 
 describe('AppleService', () => {
+  let testScheduler: TestScheduler;
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
+  });
+
   describe('getApples', () => {
     it('should return an apple', (done) => {
-      const sub = AppleService.getApples().subscribe((apple) => {
-        expect(apple._type).toBe('Apple');
-        expect(apple).toHaveProperty('color');
-        expect(['red', 'green'].includes(apple.color)).toBeTruthy();
-        expect(apple).toHaveProperty('rot');
-        done();
-        sub.unsubscribe();
+      testScheduler.run(() => {
+        const sub = AppleService.getApples().subscribe((apple) => {
+          expect(apple._type).toBe('Apple');
+          expect(apple).toHaveProperty('color');
+          expect(['red', 'green'].includes(apple.color)).toBeTruthy();
+          expect(apple).toHaveProperty('rot');
+          done();
+          sub.unsubscribe();
+        });
       });
     });
 
     it('should emit an apple every second', () => {
-      const testScheduler = new TestScheduler((actual, expected) => {
-        expect(actual).toEqual(expected);
-      });
       testScheduler.run(({ expectObservable }) => {
         const actual$ = AppleService.getApples().pipe(map(() => 'a'));
         const actualSubscription = '^ 4500ms !';
-        const expected = '- 999ms a 999ms a 999ms a 999ms a';
+        const expected = '1s a 999ms a 999ms a 999ms a';
         expectObservable(actual$, actualSubscription).toBe(expected);
       });
     });

--- a/steps/06-tests-solution/baking.service.spec.ts
+++ b/steps/06-tests-solution/baking.service.spec.ts
@@ -3,9 +3,14 @@ import { TestScheduler } from 'rxjs/testing';
 import { BakingService } from '../common/baking.service-solution';
 import { Apple, AppleSlice, Compote, PiePlate } from '../common/models';
 
-jest.setTimeout(10_000);
-
 describe('BakingService', () => {
+  let testScheduler: TestScheduler;
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
+  });
+
   describe('bakeCompote', () => {
     it('should return an compote', (done) => {
       const fourApples: Apple[] = [
@@ -14,20 +19,25 @@ describe('BakingService', () => {
         { _type: 'Apple', color: 'green', rot: false },
         { _type: 'Apple', color: 'green', rot: false },
       ];
-      const sub = BakingService.bakeCompote(fourApples).subscribe((compote) => {
-        expect(compote._type).toBe('Compote');
-        done();
-        sub.unsubscribe();
+      testScheduler.run(() => {
+        const sub = BakingService.bakeCompote(fourApples).subscribe((compote) => {
+          expect(compote._type).toBe('Compote');
+          done();
+          sub.unsubscribe();
+        });
       });
     });
+
     it('should emit an error when not enough apples are given', (done) => {
-      BakingService.bakeCompote([{ _type: 'Apple', color: 'green', rot: false }]).subscribe({
-        next() {
-          fail('should not emit a Compote');
-        },
-        error(error) {
-          done();
-        },
+      testScheduler.run(() => {
+        BakingService.bakeCompote([{ _type: 'Apple', color: 'green', rot: false }]).subscribe({
+          next() {
+            fail('should not emit a Compote');
+          },
+          error() {
+            done();
+          },
+        });
       });
     });
 
@@ -38,50 +48,56 @@ describe('BakingService', () => {
         { _type: 'Apple', color: 'green', rot: false },
         { _type: 'Apple', color: 'green', rot: false },
       ];
-      const testScheduler = new TestScheduler((actual, expected) => {
-        expect(actual).toEqual(expected);
-      });
       testScheduler.run(({ expectObservable }) => {
         const actual$ = BakingService.bakeCompote(fourApples).pipe(map(() => 'c'));
-        const expected = '- 4999ms (c|)';
+        const expected = '5s (c|)';
         expectObservable(actual$).toBe(expected);
       });
     });
   });
+
   describe('bakeApplePie', () => {
     it('should return an apple pie', (done) => {
       const pastry: PiePlate = { _type: 'PiePlate', pastry: { _type: 'PiePastry' } };
       const compote: Compote = { _type: 'Compote' };
       const appleSlices = new Array(64).fill(null).map((): AppleSlice => ({ _type: 'AppleSlice' }));
-      BakingService.bakeApplePie(pastry, compote, appleSlices).subscribe((pie) => {
-        expect(pie._type).toBe('ApplePie');
-        done();
+      testScheduler.run(() => {
+        BakingService.bakeApplePie(pastry, compote, appleSlices).subscribe((pie) => {
+          expect(pie._type).toBe('ApplePie');
+          done();
+        });
       });
     });
+
     it('should emit an error when not enough apples slices are given', (done) => {
       const pastry: PiePlate = { _type: 'PiePlate', pastry: { _type: 'PiePastry' } };
       const compote: Compote = { _type: 'Compote' };
       const appleSlices = new Array(63).fill(null).map((): AppleSlice => ({ _type: 'AppleSlice' }));
-      BakingService.bakeApplePie(pastry, compote, appleSlices).subscribe({
-        next() {
-          fail('should not emit a Compote');
-        },
-        error(error) {
-          done();
-        },
+      testScheduler.run(() => {
+        BakingService.bakeApplePie(pastry, compote, appleSlices).subscribe({
+          next() {
+            fail('should not emit a Compote');
+          },
+          error(error) {
+            done();
+          },
+        });
       });
     });
+
     it('should emit an error when not pastry are present in the plate', (done) => {
       const pastry: PiePlate = { _type: 'PiePlate' };
       const compote: Compote = { _type: 'Compote' };
       const appleSlices = new Array(64).fill(null).map((): AppleSlice => ({ _type: 'AppleSlice' }));
-      BakingService.bakeApplePie(pastry, compote, appleSlices).subscribe({
-        next() {
-          fail('should not emit a Compote');
-        },
-        error(error) {
-          done();
-        },
+      testScheduler.run(() => {
+        BakingService.bakeApplePie(pastry, compote, appleSlices).subscribe({
+          next() {
+            fail('should not emit a Compote');
+          },
+          error(error) {
+            done();
+          },
+        });
       });
     });
 
@@ -89,12 +105,9 @@ describe('BakingService', () => {
       const pastry: PiePlate = { _type: 'PiePlate', pastry: { _type: 'PiePastry' } };
       const compote: Compote = { _type: 'Compote' };
       const appleSlices = new Array(64).fill(null).map((): AppleSlice => ({ _type: 'AppleSlice' }));
-      const testScheduler = new TestScheduler((actual, expected) => {
-        expect(actual).toEqual(expected);
-      });
       testScheduler.run(({ expectObservable }) => {
         const actual$ = BakingService.bakeApplePie(pastry, compote, appleSlices).pipe(map(() => 'p'));
-        const expected = '- 4999ms (p|)';
+        const expected = '5s (p|)';
         expectObservable(actual$).toBe(expected);
       });
     });


### PR DESCRIPTION
### Problème rencontré

Lorsque j'ai fait la school j'ai eu un gros point de blocage avec les TestScheduler, je ne comprenais notamment pas du tout le pourquoi de mettre 999ms plutôt que 1s. A mes yeux ce point mérite plus d'attention.
Pour cela je propose l'ajout d'une nouvelle slide avec citations de la doc (actuellement cela prend surement un peu trop de place, il faudrait voir pour rétrécir & rendre cela plus lisible)

Je propose également de s'attarder sur la temporalité des marbles lors de l'explication de chacun, en faisant bien attention à comprendre pour chaque cas quelle est la frame à laquelle chaque event est émis ou autre (error, complete...)


### Bonus: amélioration des tests

Lorsque j'exécutais les tests j'avais un peu de mal à comprendre pourquoi ils étaient si long: cela était du au fait que plusieurs observables étaient souscrits en dehors du TestSheduler et donc en temps d'execution réel.
J'ai donc ajouté le TestSheduler dans tous les cas avec un beforeEach, permettant de passer de temps d'exécutions d'environ 12sec à 3sec