### PR TITLE
feat: simplify callbacks in step

### DIFF
--- a/steps/01-ouverture-de-l-usine-solution/index.ts
+++ b/steps/01-ouverture-de-l-usine-solution/index.ts
@@ -1,14 +1,8 @@
 import { AppleService, PiePastryService } from '../common';
 
-AppleService.getApples().subscribe((apple) => {
-  console.log(apple);
-});
+AppleService.getApples().subscribe(console.log);
 
 PiePastryService.getPiePastries().subscribe({
-  next(boxOfPiePastries) {
-    console.log(boxOfPiePastries);
-  },
-  error(error) {
-    console.error(error);
-  },
+  next: console.log,
+  error: console.error,
 });

--- a/steps/02-preparer-la-pate-solution/index.ts
+++ b/steps/02-preparer-la-pate-solution/index.ts
@@ -1,22 +1,19 @@
-import { retry, from, mergeMap, take } from 'rxjs';
+import { mergeMap, retry, take } from 'rxjs';
 import { AppleService, PiePastryService } from '../common';
 
 const APPLE_PIES_ORDERED_COUNT = 11;
 
-AppleService.getApples().subscribe((apple) => {
-  console.log(apple);
-});
+AppleService.getApples().subscribe(console.log);
 
 PiePastryService.getPiePastries()
   .pipe(
     // we retry on errors
     retry(),
     // we transform each box as a stream of PiePastry
-    // then mergeMap will transform every streams as one stream of PiePastry
+    // then mergeMap will transform every stream as one stream of PiePastry
+    // this is equivalent to `mergeMap((box) => from(box.content))` as `mergeMap` is taking care of transforming arrays into streams
     mergeMap((box) => box.content),
     // we take only the needed PiePastry
     take(APPLE_PIES_ORDERED_COUNT)
   )
-  .subscribe((boxOfPiePastries) => {
-    console.log(boxOfPiePastries);
-  });
+  .subscribe(console.log);

--- a/steps/02-preparer-la-pate/index.ts
+++ b/steps/02-preparer-la-pate/index.ts
@@ -2,19 +2,13 @@ import { AppleService, BakingService, PiePastryService } from '../common';
 
 const APPLE_PIES_ORDERED_COUNT = 11;
 
-AppleService.getApples().subscribe((apple) => {
-  console.log(apple);
-});
+AppleService.getApples().subscribe(console.log);
 
 // TODO:
 //  1. retry to subscribe to the pie pastries box stream if an error is emitted
 //  2. turn the pie pastries box stream into a pie pastrie stream (open the boxes)
 //  3. take the number of pie pastries defined in APPLE_PIES_ORDERED_COUNT
 PiePastryService.getPiePastries().subscribe({
-  next(boxOfPiePastries) {
-    console.log(boxOfPiePastries);
-  },
-  error(error) {
-    console.error(error);
-  },
+  next: console.log,
+  error: console.error,
 });

--- a/steps/03-preparer-les-pommes-solution/index.ts
+++ b/steps/03-preparer-les-pommes-solution/index.ts
@@ -1,4 +1,4 @@
-import { bufferCount, retry, from, mergeMap, take, filter } from 'rxjs';
+import { bufferCount, filter, mergeMap, retry, take } from 'rxjs';
 import { AppleService, BakingService, CuttingMachineService, PiePastryService } from '../common';
 
 const APPLE_PIES_ORDERED_COUNT = 11;
@@ -7,25 +7,23 @@ const APPLE_PIES_ORDERED_COUNT = 11;
 AppleService.getApples()
   .pipe(
     filter((apple) => !apple.rot),
-    mergeMap((apple) => from(CuttingMachineService.cutApple(apple)))
+    mergeMap(CuttingMachineService.cutApple)
   )
-  .subscribe((appleSlices) => console.log(appleSlices));
+  .subscribe(console.log);
 
 // naive bonus (process 2 different apple streams)
 AppleService.getApples()
   .pipe(
     filter((apple) => apple.rot),
     bufferCount(4),
-    mergeMap((apples) => BakingService.bakeCompote(apples))
+    mergeMap(BakingService.bakeCompote)
   )
-  .subscribe((compote) => console.log(compote));
+  .subscribe(console.log);
 
 PiePastryService.getPiePastries()
   .pipe(
     retry(),
-    mergeMap((box) => from(box.content)),
+    mergeMap((box) => box.content),
     take(APPLE_PIES_ORDERED_COUNT)
   )
-  .subscribe((boxOfPiePastries) => {
-    console.log(boxOfPiePastries);
-  });
+  .subscribe(console.log);

--- a/steps/03-preparer-les-pommes/index.ts
+++ b/steps/03-preparer-les-pommes/index.ts
@@ -1,4 +1,4 @@
-import { retry, from, mergeMap, take } from 'rxjs';
+import { mergeMap, retry, take } from 'rxjs';
 import { AppleService, PiePastryService, CuttingMachineService, BakingService } from '../common';
 
 const APPLE_PIES_ORDERED_COUNT = 11;
@@ -6,9 +6,7 @@ const APPLE_PIES_ORDERED_COUNT = 11;
 // TODO:
 //  1. remove the rotten apples
 //  2. cut the apples into slices (using `CuttingMachineService.cutApple()`)
-AppleService.getApples().subscribe((apple) => {
-  console.log(apple);
-});
+AppleService.getApples().subscribe(console.log);
 
 // TODO: Bonus (from a separate apple stream)
 //  1. take only the rotten apples
@@ -19,9 +17,7 @@ AppleService.getApples();
 PiePastryService.getPiePastries()
   .pipe(
     retry(),
-    mergeMap((box) => from(box.content)),
+    mergeMap((box) => box.content),
     take(APPLE_PIES_ORDERED_COUNT)
   )
-  .subscribe((boxOfPiePastries) => {
-    console.log(boxOfPiePastries);
-  });
+  .subscribe(console.log);

--- a/steps/04-foncer-la-tarte-solution/index.ts
+++ b/steps/04-foncer-la-tarte-solution/index.ts
@@ -1,33 +1,31 @@
-import { bufferCount, retry, from, mergeMap, take, filter, zipWith, map, share } from 'rxjs';
-import { PiePlateService } from './pie-plate.service';
+import { bufferCount, filter, map, mergeMap, retry, take, zipWith } from 'rxjs';
 import { AppleService, BakingService, CuttingMachineService, PiePastryService } from '../common';
 import { PiePlate } from '../common/models';
+import { PiePlateService } from './pie-plate.service';
 
 const APPLE_PIES_ORDERED_COUNT = 11;
 
 AppleService.getApples()
   .pipe(
     filter((apple) => !apple.rot),
-    mergeMap((apple) => from(CuttingMachineService.cutApple(apple)))
+    mergeMap(CuttingMachineService.cutApple)
   )
-  .subscribe((appleSlices) => console.log(appleSlices));
+  .subscribe(console.log);
 
 AppleService.getApples()
   .pipe(
     filter((apple) => apple.rot),
     bufferCount(4),
-    mergeMap((apples) => BakingService.bakeCompote(apples))
+    mergeMap(BakingService.bakeCompote)
   )
-  .subscribe((compote) => console.log(compote));
+  .subscribe(console.log);
 
 PiePastryService.getPiePastries()
   .pipe(
     retry(),
-    mergeMap((box) => from(box.content)),
+    mergeMap((box) => box.content),
     take(APPLE_PIES_ORDERED_COUNT),
     zipWith(PiePlateService.getPiePlate()),
     map(([piePastry, piePlate]): PiePlate => ({ ...piePlate, pastry: piePastry }))
   )
-  .subscribe((piePastryInPlate) => {
-    console.log(piePastryInPlate);
-  });
+  .subscribe(console.log);

--- a/steps/04-foncer-la-tarte/index.ts
+++ b/steps/04-foncer-la-tarte/index.ts
@@ -1,4 +1,4 @@
-import { bufferCount, retry, from, mergeMap, take, filter } from 'rxjs';
+import { bufferCount, filter, mergeMap, retry, take } from 'rxjs';
 import { AppleService, BakingService, CuttingMachineService, PiePastryService } from '../common';
 
 const APPLE_PIES_ORDERED_COUNT = 11;
@@ -6,27 +6,25 @@ const APPLE_PIES_ORDERED_COUNT = 11;
 AppleService.getApples()
   .pipe(
     filter((apple) => !apple.rot),
-    mergeMap((apple) => from(CuttingMachineService.cutApple(apple)))
+    mergeMap(CuttingMachineService.cutApple)
   )
-  .subscribe((appleSlices) => console.log(appleSlices));
+  .subscribe(console.log);
 
 AppleService.getApples()
   .pipe(
     filter((apple) => apple.rot),
     bufferCount(4),
-    mergeMap((apples) => BakingService.bakeCompote(apples))
+    mergeMap(BakingService.bakeCompote)
   )
-  .subscribe((compote) => console.log(compote));
+  .subscribe(console.log);
 
 PiePastryService.getPiePastries()
   .pipe(
     retry(),
-    mergeMap((box) => from(box.content)),
+    mergeMap((box) => box.content),
     take(APPLE_PIES_ORDERED_COUNT)
   )
-  .subscribe((boxOfPiePastries) => {
-    console.log(boxOfPiePastries);
-  });
+  .subscribe(console.log);
 
 // TODO: Each pie plate must be filled
 //  (use `PiePlateService.getPiePlate()` - be careful to import your own and not the correction one)

--- a/steps/05-cuire-la-tarte-solution/index.ts
+++ b/steps/05-cuire-la-tarte-solution/index.ts
@@ -1,14 +1,15 @@
-import { bufferCount, retry, from, mergeMap, take, filter, zipWith, map, share, zip, tap } from 'rxjs';
-import { PiePlateService } from './pie-plate.service';
+import { bufferCount, filter, map, mergeMap, retry, share, take, tap, zip, zipWith } from 'rxjs';
 import { AppleService, BakingService, CuttingMachineService, PiePastryService } from '../common';
 import { PiePlate } from '../common/models';
+import { PiePlateService } from './pie-plate.service';
 
 const APPLE_PIES_ORDERED_COUNT = 11;
 
 const apples$ = AppleService.getApples().pipe(share());
+
 const appleSlices$ = apples$.pipe(
   filter((apple) => !apple.rot),
-  mergeMap((apple) => from(CuttingMachineService.cutApple(apple))),
+  mergeMap(CuttingMachineService.cutApple),
   bufferCount(64),
   tap(console.log)
 );
@@ -16,13 +17,13 @@ const appleSlices$ = apples$.pipe(
 const compote$ = apples$.pipe(
   filter((apple) => apple.rot),
   bufferCount(4),
-  mergeMap((apples) => BakingService.bakeCompote(apples)),
+  mergeMap(BakingService.bakeCompote),
   tap(console.log)
 );
 
 const piePastryInPlate$ = PiePastryService.getPiePastries().pipe(
   retry(),
-  mergeMap((box) => from(box.content)),
+  mergeMap((box) => box.content),
   take(APPLE_PIES_ORDERED_COUNT),
   zipWith(PiePlateService.getPiePlate()),
   map(([piePastry, piePlate]): PiePlate => ({ ...piePlate, pastry: piePastry })),

--- a/steps/05-cuire-la-tarte/index.ts
+++ b/steps/05-cuire-la-tarte/index.ts
@@ -1,4 +1,4 @@
-import { bufferCount, filter, from, map, mergeMap, retry, take, zipWith } from 'rxjs';
+import { bufferCount, filter, map, mergeMap, retry, take, zipWith } from 'rxjs';
 import { AppleService, BakingService, CuttingMachineService, PiePastryService } from '../common';
 import { PiePlate } from '../common/models';
 import { PiePlateService } from './pie-plate.service';
@@ -9,28 +9,26 @@ const APPLE_PIES_ORDERED_COUNT = 11;
 AppleService.getApples()
   .pipe(
     filter((apple) => !apple.rot),
-    mergeMap((apple) => from(CuttingMachineService.cutApple(apple)))
+    mergeMap(CuttingMachineService.cutApple)
   )
-  .subscribe((appleSlices) => console.log(appleSlices));
+  .subscribe(console.log);
 
 AppleService.getApples()
   .pipe(
     filter((apple) => apple.rot),
     bufferCount(4),
-    mergeMap((apples) => BakingService.bakeCompote(apples))
+    mergeMap(BakingService.bakeCompote)
   )
-  .subscribe((compote) => console.log(compote));
+  .subscribe(console.log);
 
 PiePastryService.getPiePastries()
   .pipe(
     retry(),
-    mergeMap((box) => from(box.content)),
+    mergeMap((box) => box.content),
     take(APPLE_PIES_ORDERED_COUNT),
     zipWith(PiePlateService.getPiePlate()),
     map(([piePastry, piePlate]): PiePlate => ({ ...piePlate, pastry: piePastry }))
   )
-  .subscribe((piePastryInPlate) => {
-    console.log(piePastryInPlate);
-  });
+  .subscribe(console.log);
 
 // TODO: combine the different ingredients and cook them together to obtain pies


### PR DESCRIPTION
Remove useless `from()` operator in mergeMap
Simplify callbacks by giving directly function reference when relevant

resolve sfeir-open-source/sfeir-school-rxjs#19, resolve sfeir-open-source/sfeir-school-rxjs#20